### PR TITLE
Customize naming rule for each model

### DIFF
--- a/lib/factory_bot_cache.rb
+++ b/lib/factory_bot_cache.rb
@@ -9,8 +9,10 @@ module FactoryBotCache
     @caches = nil
   end
 
-  def name_for(base_name, key)
-    "#{base_name}_#{key}"
+  def naming_rules
+    @naming_rules ||= Hash.new do |hash, base_name|
+      hash[base_name] = ->(key){ "#{base_name}_#{key}" }
+    end
   end
 
   def caches
@@ -19,7 +21,8 @@ module FactoryBotCache
 
   def of(base_name)
     caches[base_name.to_sym] ||= Hash.new do |hash, key|
-      hash[key] = FactoryBot.create( name_for(base_name, key) )
+      naming_rule = naming_rules[base_name.to_sym]
+      hash[key] = FactoryBot.create( naming_rule[key] )
     end
   end
 

--- a/lib/factory_bot_cache/version.rb
+++ b/lib/factory_bot_cache/version.rb
@@ -1,3 +1,3 @@
 module FactoryBotCache
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
You can customize naming rule like this:

```ruby
FactoryBotCache.naming_rules[:model1] = ->(key){ key.to_s }
```
